### PR TITLE
chore(dependabot): ignore @nx dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,5 @@ updates:
     commit-message:
       prefix: "chore(deps):"
       prefix-development: "chore(dev-deps):"
+    ignore:
+      - dependency-name: "@nx/*"


### PR DESCRIPTION
<!--- In the Title above, include the type of change,(feat:, fix:,chore:, etc.]) then provide a general summary of your changes. -->

## ✳️ Description

<!--- Describe your changes in detail -->
Ignores @nx dependencies for dependabot. These dependencies are updated as part of the nx migration process.

## 🔗 Related Issue

<!--- This project only accepts outside pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/RightClickCode/RightClickCode/issues/61

## 💪 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Should remove the need to close these update PRs that depenabot would try to create for those packages.

## ⚗️ How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verify that @nx package updates aren't created by depenabot after this configuration change merges.

