### PR TITLE
chore(dependabot): ignore typescript in config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,7 @@ updates:
       - dependency-name: "@types/react-dom"
       - dependency-name: "core-js"
       - dependency-name: "eslint-config-next"
+      - dependency-name: "typescript"
     groups:
       docusaurus:
         patterns:


### PR DESCRIPTION
<!--- In the Title above, include the type of change,(feat:, fix:,chore:, etc.]) then provide a general summary of your changes. -->

## ✳️ Description

<!--- Describe your changes in detail -->
Ignores typescript in dependabot config

## 🔗 Related Issue

<!--- This project only accepts outside pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#97 

## 💪 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
typescript is updated during nx migrations. 
