### PR TITLE
chore(dependabot): ignore @babel/core in config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,7 @@ updates:
       prefix: "chore(deps):"
       prefix-development: "chore(dev-deps):"
     ignore:
+      - dependency-name: "@babel/core"
       - dependency-name: "@emotion/*"
       - dependency-name: "@nx/*"
       - dependency-name: "@swc-node/register"


### PR DESCRIPTION
<!--- In the Title above, include the type of change,(feat:, fix:,chore:, etc.]) then provide a general summary of your changes. -->

## ✳️ Description

<!--- Describe your changes in detail -->
Ignores @babel/core in dependabot config.

## 🔗 Related Issue

<!--- This project only accepts outside pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#112 

## 💪 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

@babel/core is updated during Nx migrations so it can be ignored by dependabot.
