### PR TITLE
chore(dependabot): ignore tslib in config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,7 @@ updates:
       - dependency-name: "eslint-config-next"
       - dependency-name: "eslint-plugin-cypress"
       - dependency-name: "next"
+      - dependency-name: "tslib"
       - dependency-name: "typescript"
       - dependency-name: "webpack"
     groups:


### PR DESCRIPTION
<!--- In the Title above, include the type of change,(feat:, fix:,chore:, etc.]) then provide a general summary of your changes. -->

## ✳️ Description
Adds tslib to depenabot ignore list.

<!--- Describe your changes in detail -->

## 🔗 Related Issue

<!--- This project only accepts outside pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#129 

## 💪 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

NX added tslib. Will use nx migrations to manage upgrades.

## ⚗️ How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Dependabot should no longer open PRs to update tslib

## 📸 Screenshots (if appropriate):
