### PR TITLE
chore(dependabot): ignore @typescript-eslint/parser in config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,7 @@ updates:
       - dependency-name: "@types/node"
       - dependency-name: "@types/react"
       - dependency-name: "@types/react-dom"
+      - dependency-name: "@typescript-eslint/parser"
       - dependency-name: "babel-jest"
       - dependency-name: "core-js"
       - dependency-name: "eslint-config-next"


### PR DESCRIPTION
<!--- In the Title above, include the type of change,(feat:, fix:,chore:, etc.]) then provide a general summary of your changes. -->

## ✳️ Description

<!--- Describe your changes in detail -->
Ignores @typescript-eslint/parser in dependabot config.

## 🔗 Related Issue

<!--- This project only accepts outside pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#150

## 💪 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
@typescript-eslint/parser is updated during nx migrations. 

## ⚗️ How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
CI checks should pass

## 📸 Screenshots (if appropriate):
