### PR TITLE
chore(dependabot): ignore prettier in config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,7 @@ updates:
       - dependency-name: "eslint-config-next"
       - dependency-name: "eslint-plugin-cypress"
       - dependency-name: "next"
+      - dependency-name: "prettier"
       - dependency-name: "tslib"
       - dependency-name: "ts-jest"
       - dependency-name: "typescript"


### PR DESCRIPTION
<!--- In the Title above, include the type of change,(feat:, fix:,chore:, etc.]) then provide a general summary of your changes. -->

## ✳️ Description

<!--- Describe your changes in detail -->
Ignore prettier in dependabot config.

## 🔗 Related Issue

<!--- This project only accepts outside pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#157 

## 💪 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Prettier is updated as part of the nx migrations. It can be ignored by dependabot upgrades.

## ⚗️ How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Dependabot file check should pass.

## 📸 Screenshots (if appropriate):
