### PR TITLE
chore(dependabot): ignore @swc/core in config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,7 @@ updates:
       - dependency-name: "@emotion/*"
       - dependency-name: "@nx/*"
       - dependency-name: "@swc-node/register"
+      - dependency-name: "@swc/core"
       - dependency-name: "@types/jest"
       - dependency-name: "@types/node"
       - dependency-name: "@types/react"


### PR DESCRIPTION
<!--- In the Title above, include the type of change,(feat:, fix:,chore:, etc.]) then provide a general summary of your changes. -->

## ✳️ Description

<!--- Describe your changes in detail -->
Ignores @swc/core in dependabot config.

## 🔗 Related Issue

<!--- This project only accepts outside pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#159 

## 💪 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
@swc/core is updated during the nx migrations. It can be ignored by dependabot upgrades.

## ⚗️ How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Dependabot file check should pass. 

## 📸 Screenshots (if appropriate):
