### PR TITLE
feat(nx-spellcheck): create config files

### DIFF
--- a/apps/plugins/spellcheck-e2e/tests/plugins-spellcheck.spec.ts
+++ b/apps/plugins/spellcheck-e2e/tests/plugins-spellcheck.spec.ts
@@ -15,7 +15,7 @@ describe("plugins-spellcheck e2e", () => {
   // are not dependant on one another.
   beforeAll(() => {
     ensureNxProject(
-      "@right-click/nx-spellcheck",
+      "@right-click-code/nx-spellcheck",
       "dist/libs/plugins/spellcheck"
     );
   });

--- a/libs/plugins/spellcheck/eslint.config.mjs
+++ b/libs/plugins/spellcheck/eslint.config.mjs
@@ -1,34 +1,7 @@
-import { FlatCompat } from "@eslint/eslintrc";
-import { dirname } from "path";
-import { fileURLToPath } from "url";
-import js from "@eslint/js";
 import baseConfig from "../../../eslint.config.mjs";
 
-const compat = new FlatCompat({
-  baseDirectory: dirname(fileURLToPath(import.meta.url)),
-  recommendedConfig: js.configs.recommended,
-});
-
 export default [
-  {
-    ignores: ["**/dist"],
-  },
   ...baseConfig,
-  {
-    files: ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
-    // Override or add rules here
-    rules: {},
-  },
-  {
-    files: ["**/*.ts", "**/*.tsx"],
-    // Override or add rules here
-    rules: {},
-  },
-  {
-    files: ["**/*.js", "**/*.jsx"],
-    // Override or add rules here
-    rules: {},
-  },
   {
     files: ["./package.json", "./generators.json", "./executors.json"],
     rules: {

--- a/libs/plugins/spellcheck/generators.json
+++ b/libs/plugins/spellcheck/generators.json
@@ -3,7 +3,7 @@
     "plugins-spellcheck": {
       "factory": "./src/generators/plugins-spellcheck/generator",
       "schema": "./src/generators/plugins-spellcheck/schema.json",
-      "description": "plugins-spellcheck generator"
+      "description": "Initialize project-level cspell configuration and dictionary"
     }
   }
 }

--- a/libs/plugins/spellcheck/package.json
+++ b/libs/plugins/spellcheck/package.json
@@ -1,7 +1,10 @@
 {
-  "name": "@right-click/nx-spellcheck",
+  "name": "@right-click-code/nx-spellcheck",
   "version": "0.0.1",
   "type": "commonjs",
   "executors": "./executors.json",
-  "generators": "./generators.json"
+  "generators": "./generators.json",
+  "dependencies": {
+    "@nx/devkit": "^20.8.1"
+  }
 }

--- a/libs/plugins/spellcheck/src/generators/plugins-spellcheck/files/src/index.ts.template
+++ b/libs/plugins/spellcheck/src/generators/plugins-spellcheck/files/src/index.ts.template
@@ -1,1 +1,0 @@
-const variable = "<%= name %>";

--- a/libs/plugins/spellcheck/src/generators/plugins-spellcheck/generator.spec.ts
+++ b/libs/plugins/spellcheck/src/generators/plugins-spellcheck/generator.spec.ts
@@ -19,7 +19,7 @@ describe("configure-spellcheck generator", () => {
     });
   });
 
-  it("should create root cspell config if not exists", async () => {
+  it("should create root cspell config if it does not exists", async () => {
     await configureSpellcheckGenerator(tree, options);
     expect(tree.exists(".cspell.json")).toBeTruthy();
   });
@@ -27,7 +27,7 @@ describe("configure-spellcheck generator", () => {
   it("should create project-specific config and dictionary", async () => {
     await configureSpellcheckGenerator(tree, options);
     expect(tree.exists("apps/test/.cspell.json")).toBeTruthy();
-    expect(tree.exists("apps/test/.cspell/test.txt")).toBeTruthy();
+    expect(tree.exists("apps/test/.cspell/test-dictionary.txt")).toBeTruthy();
   });
 
   it("should configure project config to extend root config", async () => {

--- a/libs/plugins/spellcheck/src/generators/plugins-spellcheck/generator.spec.ts
+++ b/libs/plugins/spellcheck/src/generators/plugins-spellcheck/generator.spec.ts
@@ -1,20 +1,40 @@
 import { createTreeWithEmptyWorkspace } from "@nx/devkit/testing";
-import { Tree, readProjectConfiguration } from "@nx/devkit";
+import { Tree, addProjectConfiguration } from "@nx/devkit";
+import { configureSpellcheckGenerator } from "./generator";
+import { ConfigureSpellcheckGeneratorSchema } from "./schema";
 
-import { pluginsSpellcheckGenerator } from "./generator";
-import { PluginsSpellcheckGeneratorSchema } from "./schema";
-
-describe("plugins-spellcheck generator", () => {
+describe("configure-spellcheck generator", () => {
   let tree: Tree;
-  const options: PluginsSpellcheckGeneratorSchema = { name: "test" };
+  const options: ConfigureSpellcheckGeneratorSchema = { project: "test" };
 
   beforeEach(() => {
     tree = createTreeWithEmptyWorkspace();
+
+    // Set up a proper project configuration using Nx's addProjectConfiguration
+    addProjectConfiguration(tree, "test", {
+      root: "apps/test",
+      sourceRoot: "apps/test/src",
+      projectType: "application",
+      targets: {},
+    });
   });
 
-  it("should run successfully", async () => {
-    await pluginsSpellcheckGenerator(tree, options);
-    const config = readProjectConfiguration(tree, "test");
-    expect(config).toBeDefined();
+  it("should create root cspell config if not exists", async () => {
+    await configureSpellcheckGenerator(tree, options);
+    expect(tree.exists(".cspell.json")).toBeTruthy();
+  });
+
+  it("should create project-specific config and dictionary", async () => {
+    await configureSpellcheckGenerator(tree, options);
+    expect(tree.exists("apps/test/.cspell.json")).toBeTruthy();
+    expect(tree.exists("apps/test/.cspell/test.txt")).toBeTruthy();
+  });
+
+  it("should configure project config to extend root config", async () => {
+    await configureSpellcheckGenerator(tree, options);
+    const configContent = JSON.parse(
+      tree.read("apps/test/.cspell.json", "utf-8")
+    );
+    expect(configContent.import).toContain("../.cspell.json");
   });
 });

--- a/libs/plugins/spellcheck/src/generators/plugins-spellcheck/generator.ts
+++ b/libs/plugins/spellcheck/src/generators/plugins-spellcheck/generator.ts
@@ -1,25 +1,77 @@
-import {
-  addProjectConfiguration,
-  formatFiles,
-  generateFiles,
-  Tree,
-} from "@nx/devkit";
-import * as path from "path";
-import { PluginsSpellcheckGeneratorSchema } from "./schema";
+import { Tree, formatFiles, getProjects, joinPathFragments } from "@nx/devkit";
+import { ConfigureSpellcheckGeneratorSchema } from "./schema";
 
-export async function pluginsSpellcheckGenerator(
+function ensureRootCSpellConfig(tree: Tree) {
+  const rootConfigPath = ".cspell.json";
+  if (!tree.exists(rootConfigPath)) {
+    const rootConfig = {
+      version: "0.2",
+      language: "en",
+      allowCompoundWords: true,
+      dictionaries: [],
+      dictionaryDefinitions: [],
+      ignorePaths: [
+        "node_modules",
+        "dist",
+        "coverage",
+        ".git",
+        "pnpm-lock.yaml",
+      ],
+    };
+    tree.write(rootConfigPath, JSON.stringify(rootConfig, null, 2));
+  }
+}
+
+function createProjectConfig(
   tree: Tree,
-  options: PluginsSpellcheckGeneratorSchema
+  projectName: string,
+  projectRoot: string
 ) {
-  const projectRoot = `libs/${options.name}`;
-  addProjectConfiguration(tree, options.name, {
-    root: projectRoot,
-    projectType: "library",
-    sourceRoot: `${projectRoot}/src`,
-    targets: {},
-  });
-  generateFiles(tree, path.join(__dirname, "files"), projectRoot, options);
+  const projectConfigPath = joinPathFragments(projectRoot, ".cspell.json");
+  const dictionaryPath = joinPathFragments(projectRoot, ".cspell");
+  const dictionaryFile = joinPathFragments(
+    dictionaryPath,
+    `${projectName}-dictionary.txt`
+  );
+
+  // Create .cspell directory
+  tree.write(dictionaryFile, `# ${projectName} dictionary\n`);
+
+  // Create project-specific cspell config
+  const projectConfig = {
+    version: "0.2",
+    import: ["../.cspell.json"],
+    dictionaryDefinitions: [
+      {
+        name: `${projectName}-dictionary`,
+        path: `./.cspell/${projectName}-dictionary.txt`,
+        addWords: true,
+      },
+    ],
+    dictionaries: [`${projectName}-dictionary`],
+  };
+
+  tree.write(projectConfigPath, JSON.stringify(projectConfig, null, 2));
+}
+
+export async function configureSpellcheckGenerator(
+  tree: Tree,
+  options: ConfigureSpellcheckGeneratorSchema
+) {
+  const projects = getProjects(tree);
+  const project = projects.get(options.project);
+
+  if (!project) {
+    throw new Error(`Project ${options.project} not found`);
+  }
+
+  // Ensure root config exists
+  ensureRootCSpellConfig(tree);
+
+  // Create project-specific config and dictionary
+  createProjectConfig(tree, options.project, project.root);
+
   await formatFiles(tree);
 }
 
-export default pluginsSpellcheckGenerator;
+export default configureSpellcheckGenerator;

--- a/libs/plugins/spellcheck/src/generators/plugins-spellcheck/schema.d.ts
+++ b/libs/plugins/spellcheck/src/generators/plugins-spellcheck/schema.d.ts
@@ -1,3 +1,3 @@
-export interface PluginsSpellcheckGeneratorSchema {
-  name: string;
+export interface ConfigureSpellcheckGeneratorSchema {
+  project: string;
 }

--- a/libs/plugins/spellcheck/src/generators/plugins-spellcheck/schema.json
+++ b/libs/plugins/spellcheck/src/generators/plugins-spellcheck/schema.json
@@ -1,18 +1,17 @@
 {
   "$schema": "http://json-schema.org/schema",
   "$id": "PluginsSpellcheck",
-  "title": "",
+  "title": "Configure Spellcheck",
   "type": "object",
   "properties": {
-    "name": {
+    "project": {
       "type": "string",
-      "description": "",
+      "description": "The name of the project to configure spellcheck for",
       "$default": {
         "$source": "argv",
         "index": 0
-      },
-      "x-prompt": "What name would you like to use?"
+      }
     }
   },
-  "required": ["name"]
+  "required": ["project"]
 }

--- a/libs/plugins/spellcheck/src/generators/plugins-spellcheck/schema.json
+++ b/libs/plugins/spellcheck/src/generators/plugins-spellcheck/schema.json
@@ -10,7 +10,8 @@
       "$default": {
         "$source": "argv",
         "index": 0
-      }
+      },
+      "x-prompt": "What project would you like to configure spellcheck for?"
     }
   },
   "required": ["project"]

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,7 +15,9 @@
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "paths": {
-      "@right-click/nx-spellcheck": ["libs/plugins/spellcheck/src/index.ts"]
+      "@right-click-code/nx-spellcheck": [
+        "libs/plugins/spellcheck/src/index.ts"
+      ]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
<!--- In the Title above, include the type of change,(feat:, fix:,chore:, etc.]) then provide a general summary of your changes. -->

## ✳️ Description

<!--- Describe your changes in detail -->
Generator creates initial .cspell.json config and an initial project level dictionary.

## 🔗 Related Issue

<!--- This project only accepts outside pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## 💪 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Initialize a project with cspell

## ⚗️ How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests and tested locally with 
`pnpm nx g @right-click/nx-spellcheck:plugins-spellcheck --project=docs`

## 📸 Screenshots (if appropriate):
